### PR TITLE
Fix typo in manfile

### DIFF
--- a/lnav.1
+++ b/lnav.1
@@ -92,7 +92,7 @@ directory will be loaded.
 To load and follow the syslog file:
 .PP
 .Vb 1
-\&    lnav \-s
+\&    lnav
 .Ve
 .PP
 To load all of the files in /var/log:


### PR DESCRIPTION
Remove useless -s parameter as it does not seem to be used any more.